### PR TITLE
Timeout after 3 mins in run.py and don't capture stdout

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,16 +4,18 @@ import sys
 import subprocess as sp
 
 program = ["target/release/ewok"]
+timeout = 180
 
 def main():
     i = 0
     while True:
         print("run {}".format(i))
         try:
-            sp.run(program, stdout=sp.PIPE, check=True)
+            sp.run(program, check=True, timeout=timeout)
         except sp.CalledProcessError as e:
-            print(e.output)
             sys.exit(1)
+        except sp.TimeoutExpired as e:
+            print("timed out after {} seconds".format(e.timeout))
         i += 1
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes it easy to get the seeds for diverging runs, the output just looks like:

```
run 0
Seed: [2799202095, 1218792825, 364611759, 1526010974]
run 1
Seed: [2465837942, 2370558436, 2699833361, 4078690520]
...
```