### PR TITLE
Implement ForceMerge rule

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,15 +1,49 @@
 use name::Name;
 use block::{Block, Vote, CurrentBlocks, our_blocks, blocks_for_prefix};
+use peer_state::PeerStates;
 use std::collections::BTreeSet;
 use std::cmp;
 
 pub fn merge_blocks(current_blocks: &CurrentBlocks,
+                    peer_states: &PeerStates,
                     our_name: Name,
                     min_section_size: usize)
                     -> Vec<Vote> {
-    merge_rule(current_blocks, our_name, min_section_size)
-        .into_iter()
-        .collect()
+    let mut result = merge_rule(current_blocks, our_name, min_section_size);
+    result.extend(force_merge_rule(current_blocks, peer_states, our_name));
+    result.into_iter().collect()
+}
+
+fn force_merge_rule(current_blocks: &CurrentBlocks,
+                    peer_states: &PeerStates,
+                    our_name: Name)
+                    -> BTreeSet<Vote> {
+    let mut votes = BTreeSet::new();
+    for candidate in current_blocks
+            .iter()
+            .filter(|&b| lost_quorum(b, peer_states)) {
+        for our_block in our_blocks(current_blocks, our_name).filter(|b| {
+                                                                         b.prefix.sibling() ==
+                                                                         Some(candidate.prefix)
+                                                                     }) {
+            let target = merged_block(candidate, our_block);
+            let vote = Vote {
+                from: our_block.clone(),
+                to: target,
+            };
+            votes.insert(vote);
+        }
+    }
+    votes
+}
+
+fn lost_quorum(block: &Block, peer_states: &PeerStates) -> bool {
+    let num_active = block
+        .members
+        .iter()
+        .filter(|&name| !peer_states.is_disconnected_from(name))
+        .count();
+    num_active <= block.members.len() / 2
 }
 
 fn merge_rule(current_blocks: &CurrentBlocks,

--- a/src/node.rs
+++ b/src/node.rs
@@ -233,6 +233,7 @@ impl Node {
         }
 
         for vote in merge_blocks(&self.current_blocks,
+                                 &self.peer_states,
                                  self.our_name,
                                  self.params.min_section_size) {
             trace!("{}: voting to merge from: {:?} to: {:?}",


### PR DESCRIPTION
I think this should take care of what is in the proposal.

However, maybe it should be extended a bit. For now we only check lost connections in the sibling section. It wouldn't work in a situation where we are, let's say, `11`, and it's `0` that lost over a half of its nodes. `0` would then never validate a block that says it's too small, which wouldn't trigger the **Merge** rule. So, maybe we should check not only our siblings, but also siblings of our ancestors, similar to how the **Merge** rule works.