### PR TITLE
Vet connection requests and improve in-order message delivery

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -729,6 +729,11 @@ impl Node {
             .collect()
     }
 
+    fn should_be_connected(&self, node: Name, blocks: &Blocks) -> bool {
+        let neighbours = nodes_in_any(blocks, &self.current_blocks);
+        neighbours.contains(&node)
+    }
+
     /// Handle a message intended for us and return messages we'd like to send.
     pub fn handle_message(&mut self, message: Message, blocks: &Blocks, step: u64) -> Vec<Message> {
         let to_send = match message.content {
@@ -742,6 +747,7 @@ impl Node {
                     Candidate { step_added: step },
                 );
                 self.connections.insert(joining_node);
+                self.connect_requests.insert(joining_node);
 
                 let connect_msg = Message {
                     sender: self.our_name,
@@ -801,21 +807,34 @@ impl Node {
                 vec![]
             }
             Connect => {
-                if self.connections.insert(message.sender) {
-                    debug!("{}: obtained a connection to {}", self, message.sender);
-                }
-                if !self.connect_requests.contains(&message.sender) {
-                    trace!("{}: connecting back to {}", self, message.sender);
-                    self.connect_requests.insert(message.sender);
+                if self.should_be_connected(message.sender, blocks) {
+                    if self.connections.insert(message.sender) {
+                        debug!("{}: obtained a connection to {}", self, message.sender);
+                    }
+                    if !self.connect_requests.contains(&message.sender) {
+                        trace!("{}: connecting back to {}", self, message.sender);
+                        self.connect_requests.insert(message.sender);
+                        vec![
+                            Message {
+                                sender: self.our_name,
+                                recipient: message.sender,
+                                content: MessageContent::Connect,
+                            },
+                        ]
+                    } else {
+                        vec![]
+                    }
+                } else {
+                    trace!("{}: rejecting connection request from {}", self, message.sender);
+                    self.connections.remove(&message.sender);
+                    self.connect_requests.remove(&message.sender);
                     vec![
                         Message {
                             sender: self.our_name,
                             recipient: message.sender,
-                            content: MessageContent::Connect,
-                        },
+                            content: Disconnect,
+                        }
                     ]
-                } else {
-                    vec![]
                 }
             }
             RequestProof(block, current_blocks) => {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -367,6 +367,7 @@ impl Simulation {
         debug!("-- final node states --");
         for node in self.nodes.values() {
             debug!("{:?}", node.as_debug(&self.blocks));
+            trace!("{:#?}", node.connections);
         }
 
         assert!(


### PR DESCRIPTION
This PR includes 2 main changes on top of the `quorum-to` branch:

1. Only connect back to nodes when we receive a `Connect` message if we think we should be connected to them. This seems to fix connect-disconnect loops.
2. Deliver messages in-order, _even if they were sent at the same step_. Previously we allowed messages sent at the same step to get out of order, and as part of debugging the implementation of part (1) I figured I would fix this. I think it makes sense for a `Connect` and a `Disconnect` sent on the same step (either side of an `update_state()` call perhaps) to be delivered in order so that the node at the other end doesn't get confused...